### PR TITLE
Boolean reduction logic for Reduct library

### DIFF
--- a/boolean-reduction/examples.metta
+++ b/boolean-reduction/examples.metta
@@ -1,0 +1,189 @@
+!(import! &self reduce)
+
+; ################################################## AND
+
+;; !(assertEqual
+;;     (reduce (AND a True))
+;;     a
+;; )
+;; !(assertEqual
+;;     (reduce (AND True a))
+;;     a
+;; )
+;; !(assertEqual
+;;     (reduce (AND a b))
+;;     (AND a b)
+;; )
+;; !(assertEqual
+;;     (reduce (AND a (AND a c)))
+;;     (AND a c)
+;; )
+;; !(assertEqual
+;;     (reduce (AND a (AND b False)))
+;;     False
+;; )
+;; !(assertEqual
+;;     (reduce (AND a (AND b (AND a (AND a (AND a True))))))
+;;     (AND b a)
+;; )
+;; !(assertEqual
+;;     (reduce (AND a (AND b (AND a (AND a (AND a False))))))
+;;     False
+;; )
+;; !(assertEqual
+;;     (reduce (AND A (AND B (AND C (AND (OR A (OR B (OR C A))) (AND B (AND (AND A A) (NOT A))))))))
+;;     False
+;; )
+
+; ################################################## OR
+;; !(assertEqual
+;;     (reduce (OR a b))
+;;     (OR a b)
+;; )
+;; !(assertEqual
+;;     (reduce (OR (AND a b) (AND a b)))
+;;     (AND a b)
+;; )
+;; !(assertEqual
+;;     (reduce (OR a (OR b (OR c (OR d True)))))
+;;     True
+;; )
+;; !(assertEqual
+;;     (reduce (OR a (AND b (AND c (AND d False)))))
+;;     a
+;; )
+;; !(assertEqual
+;;     (reduce (OR (AND a b) (OR a True)))
+;;     True
+;; )
+
+; ################################################## NOT
+;; !(assertEqual
+;;     (reduce (NOT a))
+;;     (NOT a)
+;; )
+;; !(assertEqual
+;;     (reduce (NOT (NOT a)))
+;;     a
+;; )
+;; !(assertEqual
+;;     (reduce (NOT (AND a b)))
+;;     (OR (NOT a) (NOT b))
+;; )
+;; !(assertEqual
+;;     (reduce (NOT (OR a b)))
+;;     (AND (NOT a) (NOT b))
+;; )
+;; !(assertEqual
+;;     (reduce (NOT (NOT (AND A B))))
+;;     (AND A B)
+;; )
+
+; ################################################## XOR
+;; !(assertEqual
+;;     (reduce (XOR (OR (NOT A) C) (OR (AND (NOT A) B) (NOT C))))
+;;     (XOR (OR C (NOT A)) (OR (AND B (NOT A)) (NOT C)))
+;; )
+;; !(assertEqual
+;;     (reduce (XOR (OR (NOT A) A) (OR (AND (NOT A) B) True)))
+;;     False
+;; )
+;; !(assertEqual
+;;     (reduce (XOR a (AND a a)))
+;;     False
+;; )
+;; !(assertEqual
+;;     (reduce (XOR True False))
+;;     True
+;; )
+;; !(assertEqual
+;;     (reduce (XOR True True))
+;;     False
+;; )
+
+;; ; ******************* Associativity example *******************
+
+;; !(assertEqual
+;;     (reduce (OR (OR (NOT A) (AND A (AND B C))) (AND B (AND C (NOT B)))))
+;;     (OR (NOT A) (AND A (AND B C)))
+;; )
+;; !(assertEqual
+;;     (reduce (OR (OR (NOT A) (AND A (AND B C))) (AND C (AND B (NOT B)))))
+;;     (OR (NOT A) (AND A (AND B C)))
+;; )
+
+
+;; ; ******************* ENF examples *******************
+;; ; Rule 4
+;; !(assertEqual
+;;     (reduce (AND a (OR b (AND c (OR d (AND e (NOT a)))))))
+;;     (OR (AND a b) (AND a (AND c d)))
+;; )
+ 
+;; !(assertEqual
+;;     (reduce (OR (OR (AND a b) (AND a (AND c d))) (AND a (AND c (AND e (NOT a))))))
+;;     (OR (AND a b) (AND a (AND c d)))
+;; )
+
+;; !(assertEqual
+;;     (reduce (OR (AND a b) (AND a (AND c (OR d (AND e (NOT a)))))))
+;;     (OR (AND a b) (AND a (AND c d)))
+;; )
+
+;; !(assertEqual
+;;     (reduce (OR (AND a b) (AND a (AND c (OR d (AND e a))))))
+;;     (OR (AND a b) (OR (AND a (AND c d)) (AND c (AND e a))))
+;; )
+
+;; !(assertEqual
+    ; (reduce (AND a (OR b (AND c (OR d (OR e a))))))
+    ; (OR (AND a b) (OR (AND a (AND c d)) (OR (AND a (AND c e)) (AND c a))))  
+    ; This is correct but it can be further reduced:
+    ; (OR (AND a b) (AND a c))
+    ; The problem is that it doesn't reduce (OR (AND c a) (OR (AND a (AND c d)))) to (AND c a)
+;; )
+
+;; !(assertEqual
+;;     (reduce (OR (AND a b) (OR (AND a (AND c d)) (OR (AND a (AND c e)) (AND c a)))))
+;;     (OR (AND a b) (OR (AND a (AND c d)) (OR (AND a (AND c e)) (AND c a))))
+        ; This can be further reduced:
+;;     (OR (AND a b) (AND c a))
+;; )
+
+;; !(assertEqual    ; time: 40m20s
+;;      (reduce (OR (AND a b) (AND a (AND c (OR d (OR e a)))))) 
+;;      (OR (AND a b) (OR (AND a (AND c d)) (OR (AND a (AND c e)) (AND c a))))
+        ;This can be further reduced
+;;      (OR (AND a b) (AND a c))
+;; )
+
+;; !(assertEqual    ; time: 41m53s
+;;     (reduce (OR (AND a b) (AND a (AND c (OR d (OR e (NOT a)))))))
+;;     (OR (AND a b) (OR (AND a (AND c d)) (AND a (AND c e))))
+        ;This can be further reduced
+    ;; (OR (AND a b) (OR (AND a (AND c d)) (OR (AND a (AND c e)))))
+;; )
+
+; ******************* Examples from Holman's PhD thesis *******************
+; Example from Holman paper (page 19)
+;; !(assertEqual
+;;     (reduce (AND (NOT (OR (OR a (AND (NOT b) a)) c)) b))
+;;     (AND b (AND (NOT a) (NOT c)))
+;; )
+;; !(assertEqual
+;;     (reduce (AND (AND (AND (NOT a) (OR (NOT b) (NOT a))) (NOT c)) b))
+;;     (AND b (AND (NOT a) (NOT c)))
+;; )
+
+; Example from Holman paper (page 19)
+;; !(assertEqual
+;;     (reduce (AND (AND (AND (NOT a) (OR (NOT b) (NOT a))) (NOT c)) b))
+;;     (AND b (AND (NOT a) (NOT c)))
+;; )
+
+
+;** TODO: Implement more flexible reduction logic **
+;; !(assertEqual
+;;     (reduce (OR (AND (AND c a) d) (OR (AND c a) (AND (AND c a) e))))
+;;     (AND c a)
+;; )

--- a/boolean-reduction/reduce.metta
+++ b/boolean-reduction/reduce.metta
@@ -1,0 +1,183 @@
+!(import! &self rules)
+!(import! &self utils)
+
+; Main function to call for reducing boolean expressions
+(= (reduce $EXPR)
+    ; Print the unreduced expression (this is called recursively)
+    (let* ((() (println! ("Reduce: " $EXPR))))
+    ; First argument is an empty expression at first
+    (compare-and-reduce () $EXPR)
+    )
+)
+
+; expression2 is reduced and compared to expression1 (which is the unreduced expression)
+(= (compare-and-reduce $EXPR1 $EXPR2)
+    ; Print both expressions
+    (let* ((() (println! ("Compare:" $EXPR1 $EXPR2))))
+    ; If expression2 is not a literal and if it's not the same as the unreduced expression
+    (if (and (== (get-metatype $EXPR2) Expression) (not (== $EXPR1 $EXPR2)))
+        ; Continue reducing expression2
+        (compare-and-reduce $EXPR2 (reduce-expression $EXPR2))
+        ; Return expression2 because can't be further reduced
+        $EXPR2
+    )
+    )
+)
+
+; Call reduction functions for each type of expression correspondingly
+(= (reduce-expression $_EXPR)
+    ; Sort the outer expression (grounded < symbol < expression)
+    (let $EXPR (sort $_EXPR)
+        (if (== (get-metatype $EXPR) Expression)
+                (case $EXPR
+                    (
+                        ((AND $EXPR1 $EXPR2) (reduce-and-expression $EXPR))
+                        ((OR $EXPR1 $EXPR2) (reduce-or-expression $EXPR))
+                        ((NOT $EXPR1) (reduce-not-expression $EXPR))
+                        ((XOR $EXPR1 $EXPR2) (reduce-xor-expression $EXPR))
+                        ; (... add more operations)
+                        ($else (Error "Invalid boolean expression"))
+                    )
+                )
+            ; In case we try to reduce a literal
+            $EXPR
+        )
+    )
+)
+
+; #################################################################################################
+
+; Reduction function for AND expressions
+(= (reduce-and-expression $EXPR)
+    (case $EXPR
+        (
+            ; Apply some AND reduction rules by pattern matching
+            ( (AND False $a) False)                 ; (a and False)  -->  False             (annulment/identity law)
+            ( (AND True $a) $a)                     ; (a and True)  -->  a                  (identity law)
+            ( (AND $a (NOT $a)) False)              ; (a and -a)  -->  False                (complement law)
+            ( (AND $a $a) $a)                       ; (a and a)  -->  a                     (idempotent law)
+
+            ; For all other cases of AND expressions
+            ( (AND $a $b)
+                ; If either a or b is an expression
+                (if (or (== (get-metatype $a) Expression) (== (get-metatype $b) Expression))
+                    (let $_EXPR (apply-reduction-rules $EXPR)
+                        (if (== (get-metatype $_EXPR) Expression)
+                            (reduce-recursive $_EXPR)
+                            $_EXPR
+                        )
+                    )
+                    ; If a and b are literals
+                    $EXPR
+                )
+            )
+            ( $else (Error "Invalid AND expression"))
+        )
+    )
+)
+
+; Reduction function for OR expressions
+(= (reduce-or-expression $EXPR)
+    (case $EXPR
+        (
+            ; Apply some OR reduction rules by pattern matching
+            ( (OR True $a) True)                ; (a OR True)  -->  True
+            ( (OR False $a) $a)                 ; (a OR False)  -->  a
+            ( (OR $a $a) $a)                    ; (a OR a)  -->  a
+            ( (OR $a (NOT $a)) True)            ; (a OR -a)  -->  True
+
+            ; For all other cases of OR expressions
+            ( (OR $a $b)
+                ; If either a or b is an expression
+                (if (or (== (get-metatype $a) Expression) (== (get-metatype $b) Expression))
+                    (let $_EXPR (apply-reduction-rules $EXPR)
+                        (if (== (get-metatype $_EXPR) Expression)
+                            (reduce-recursive $_EXPR)
+                            $_EXPR
+                        )
+                    )
+                    ; If a and b are literals
+                    $EXPR
+                )
+            )
+            ( $else (Error "Invalid OR expression"))
+        )
+    )
+)
+
+; Reduction function for NOT expressions
+(= (reduce-not-expression $EXPR)
+    (case $EXPR
+        (
+            ; Apply NOT reduction rules by pattern matching
+            ( (NOT True) False)                             ; (-(-a))  -->  a
+            ( (NOT False) True)                             ; (-(-a))  -->  a
+            ( (NOT (NOT $a)) $a)                            ; (-(-a))  -->  a
+            ( (NOT (AND $a $b)) (OR (NOT $a) (NOT $b)) )    ; -(a AND b)  -->  (-a OR -b)
+            ( (NOT (OR $a $b)) (AND (NOT $a) (NOT $b)) )    ; -(a OR b)  -->  (-a AND -b)
+            ( (NOT $a) 
+                (if (== (get-metatype $a) Expression)
+                    (reduce-recursive $EXPR)
+                    $EXPR
+                )
+            )
+            ( $else (Error "Invalid NOT expression"))
+        )
+    )
+)
+
+; Reduction function for XOR expressions
+(= (reduce-xor-expression $EXPR)
+    (case $EXPR
+        (
+            ( (XOR $a $a) False)             ; (a XOR a)  -->  False
+            ( (XOR $a $b)
+                ; Check if the sub-expressions can't be further reduced
+                (if (or (and (== (get-metatype $a) Symbol) (== (get-metatype $b) Symbol))
+                        (and (== (get-metatype $a) Grounded) (== (get-metatype $b) Grounded)))
+                    True
+                    ; Further reduce the sub-expressions
+                    (reduce-recursive $EXPR)
+                )
+            )
+            ( $else (Error "Invalid XOR expression"))
+        )
+    )
+)
+
+; (... add more reduction functions) (NAND | NOT | XNOR | IMP | BI-IMP)
+
+; #################################################################################################
+
+; Function to recursively apply reuction to sub-expressions
+(= (reduce-recursive $EXPR)
+    (let*
+        (
+            ; Sort the expression (grounded < symbol < expression)
+            ($_EXPR (sort $EXPR))
+            (() (println! ("Reduce Recursive: " $_EXPR)))
+        )
+        (case $_EXPR
+            (
+                (
+                    ($OP $exp1 $exp2) 
+                    (if (== (get-metatype $exp1) Expression)
+                        (compare-and-reduce $_EXPR ($OP (reduce $exp1) (reduce $exp2)))
+                        (if (== (get-metatype $exp2) Expression) ;--
+                            (compare-and-reduce $_EXPR ($OP $exp1 (reduce $exp2)))
+                            $_EXPR ;--
+                        ) ;--
+                    )
+                )
+                (
+                    ($OP $exp1) 
+                    (if (== (get-metatype $exp1) Expression)
+                        (compare-and-reduce $_EXPR ($OP (reduce $exp1)))
+                        $_EXPR
+                    )
+                )
+                ( $else (Error "Invalid expression"))
+            )
+        )
+    )
+)

--- a/boolean-reduction/rules.metta
+++ b/boolean-reduction/rules.metta
@@ -1,0 +1,68 @@
+!(import! &self utils)
+
+; Function to apply distributive property to an expression
+(= (distrubutive-law $exp)
+    (case $exp
+        (
+            ( (AND $a (OR $b $c))           ; (a AND (b OR c))  -->  ((a AND b) OR (a AND c))
+                (if (== (get-metatype $a) Expression)
+                    $exp
+                    (OR (AND $a $b) (AND $a $c))
+                )
+            )
+            ( (OR $a (AND $b $c))           ; (a OR (b AND c))  -->  ((a OR b) AND (a OR c))
+                (if (== (get-metatype $a) Expression)
+                    $exp
+                    (AND (OR $a $b) (OR $a $c))
+                )
+            )
+            ( $else $exp)
+        )
+    )
+)
+
+;** TODO **
+; Write other recursive boolean reduction rules: identity | complement | annulment | absorption
+
+(= (apply-and-reduction-rules (AND $a $b))
+    (if (member AND $a $b)       ; (a AND (a AND b))  -->  (a AND b)     (idempotent law)
+        $b
+        (if (member OR $a $b)           ; a AND (a OR b)  -->  a                (absorption law)
+            $a
+            (if (member AND (NOT $a) $b)            ; (a AND ((not a) AND b))  -->  False     (annulment law)
+                False
+                (if (== (get-metatype $a) Expression)
+                    (AND $a $b)
+                    (distrubutive-law (AND $a $b))          ; (distributive property)
+                )
+            )
+        )
+    )
+)
+
+; The problem is that it doesn't reduce (OR (AND c a) (OR (AND a (AND c d)))) to (AND c a)
+(= (apply-or-reduction-rules (OR $a $b))
+    (if (member OR $a $b)       ; (a OR (a OR b))  -->  (a OR b)        (idempotent law)
+        $b
+        (if (member AND $a $b)          ; a OR (a AND b)  -->  a                (absorption law)
+            $a
+            (if (member OR (NOT $a) $b)         ; (a OR ((not a) OR b))  -->  True       (annulment law)
+                True
+                (if (== (get-metatype $a) Expression)
+                    (OR $a $b)
+                    (distrubutive-law (OR $a $b))          ; (distributive property)
+                )
+            )
+        )
+    )
+)
+
+(= (apply-reduction-rules $expr)
+    (case $expr
+        (
+            ((AND $a $b) (apply-and-reduction-rules $expr))
+            ((OR $a $b) (apply-or-reduction-rules $expr))
+            ($else $expr)
+        )
+    )
+)

--- a/boolean-reduction/utils.metta
+++ b/boolean-reduction/utils.metta
@@ -1,0 +1,50 @@
+; Function to compare two Atoms based on their metatypes (less than or equal to)
+    ; (grounded < symbol < expression < variable)
+(= (lte $a $b)
+    (let* ( ($type-a (get-metatype $a))
+            ($type-b (get-metatype $b)))
+        (if (== $type-a $type-b)
+            True
+            (if (== $type-a Grounded)
+                True
+                (if (and (== $type-a Symbol) (or (== $type-b Expression) (== $type-b Variable)))
+                    True
+                    (if (and (== $type-a Expression) (== $type-b Variable))
+                        True
+                        False ;; add other conditions
+                    )
+                ))
+        )
+    )
+)
+
+; Fnuction to sort an outer expression based on their metatypes
+(= (sort $expr)
+    (case $expr
+        (
+            (($OP $a $b) 
+                (if (lte $a $b)
+                    ($OP $a $b)
+                    ($OP $b $a)
+                )
+            )
+            ($else $expr)
+        )
+    )
+)
+
+; Function to check whether a certain sub-expression is part of another expression
+(= (member $op $sub_exp $EXP)
+    (if (== (get-metatype $EXP) Expression)
+        (case $EXP
+            (
+                ( ($op $a $b) (or (member $op $sub_exp $a) (member $op $sub_exp $b)) )
+                ( $else (== $sub_exp $EXP) )
+            )
+        )
+        (== $sub_exp $EXP)
+    )
+)
+
+;** TODO **
+; Write other helper functions: equal | subset


### PR DESCRIPTION
**Logic to recursively reduce Boolean Expressions** 

This follows a top-down approach to reduction, meaning that it first tries to reduce the whole expression before trying to reduce the sub-expressions recursively.

On every round of reduction, it compares the reduced expression with the previously unreduced expression to ensure that an expression can't be further reduced using this reduction logic.

This reduction logic is modularized so that it is suitable to add more functions for reducing other types of expressions (NAND, NOR, XNOR, …). It is also very easy to add more rules to the existing reduction functions.

_This includes the following MeTTa scripts:_
- `reduce.metta` : This includes the main reduce function and also other helper functions to recursively reduce different types of expressions (AND, OR, NOT, XOR).
- `rules.metta` : This includes additional rules that may be applied to unreduced expressions (more rules will be added here).
- `utils.metta` : This includes helper functions to be used on the expressions being reduced.
- `examples.metta` : This includes sample test cases for reducing various boolean expressions.